### PR TITLE
Use better rangeslider for player view - incl. display of market average on slider

### DIFF
--- a/market/forms.py
+++ b/market/forms.py
@@ -142,35 +142,35 @@ class TradeForm(forms.ModelForm):
         model = Trade
         fields = ('unit_price', 'unit_amount')
         widgets = {
-            'unit_price': forms.NumberInput(attrs={'type': 'range', 'min': 0, 'class': 'slider', 'step': 0.1}),
-            'unit_amount': forms.NumberInput(attrs={'type': 'range', 'min': 0, 'class': 'slider', 'step': 1}),
-        }
-        labels = {
-            'unit_price': _('Price')+': ',
-            'unit_amount': _('Amount')+': '
-        }
-        help_texts = {
-            'unit_amount': ('How many units do you want to produce?'),
+            'unit_price': forms.NumberInput(attrs={'type': 'text', 'class': 'price-slider'}),
+            'unit_amount': forms.NumberInput(attrs={'type': 'text', 'class': 'production-slider'}),
         }
 
-    def __init__(self, trader=None, *args, **kwargs):
+    def __init__(self, trader=None, market_average=None, *args, **kwargs):
         super(TradeForm, self).__init__(*args, **kwargs)
 
         if trader:
             # traders can set the price of a product up to 5 times market's maximal prod cost
-            self.fields['unit_price'].widget.attrs['max'] = 5 * \
-                trader.market.max_cost
+            self.fields['unit_price'].widget.attrs['min'] = 0
+            self.fields['unit_price'].widget.attrs['max'] = 5 * trader.market.max_cost
 
             # make sure, trader can't choose to produce an amount of units, he can't afford
             if trader.prod_cost > 0:
                 max_unit_amount = floor((trader.balance/trader.prod_cost))
             else:  # if prod_cost is 0 (this is currently not allowed to happen)
                 max_unit_amount = 10000  # this number is arbitrary
+            self.fields['unit_amount'].widget.attrs['min'] = 0
             self.fields['unit_amount'].widget.attrs['max'] = max_unit_amount
 
-            self.fields['unit_price'].help_text = (_("Set a price for one {0} (your cost pr. {0} is <b>{1}</b> kr.)")).format(
-                trader.market.product_name_singular, trader.prod_cost)
-            self.fields['unit_amount'].help_text = (
+            # Only show market average after round 0
+            if trader.market.round > 0 and market_average is not None:
+                self.fields['unit_price'].widget.attrs['marketavg'] = market_average
+
+            # Labels
+            self.fields['unit_price'].label = (
+                _("Set your price for one {0}")).format(trader.market.product_name_singular)
+
+            self.fields['unit_amount'].label = (
                 _("How many {0} do you want to produce?")).format(trader.market.product_name_plural)
 
             # Set default value of price slider equal to the trader's prod cost

--- a/market/management/commands/setup_test_data.py
+++ b/market/management/commands/setup_test_data.py
@@ -4,7 +4,7 @@ import random
 from django.db import transaction
 from django.core.management.base import BaseCommand
 
-from market.tests.factories import (UserFactory)
+from market.tests.factories import UserFactory, MarketFactory
 
 
 # from forum.models import User, Thread, Club, Comment
@@ -30,6 +30,10 @@ class Command(BaseCommand):
 
         person = UserFactory(username="test",
                              password="test")
+
+        self.stdout.write("Adding test markets")
+        market1 = MarketFactory(market_id="FOO", created_by=person)
+        market2 = MarketFactory(market_id="BAR", created_by=person)
         
         # self.stdout.write("Deleting old data...")
         # models = [User, Thread, Comment, Club]

--- a/market/static/style.css
+++ b/market/static/style.css
@@ -15,7 +15,7 @@
     transform-origin: left top;
     transform: rotate(20deg);
     padding: 1px 3px;
-    background-color: rgba(0,0,0,0.1);
+    background-color: #e1e1e1;
     border-radius: 3px;
 }
 

--- a/market/static/style.css
+++ b/market/static/style.css
@@ -7,3 +7,18 @@
         display: none;
     }
 }
+
+.slider_mark {
+    display: block;
+    position: absolute;
+    top: 45px;
+    transform-origin: left top;
+    transform: rotate(20deg);
+    padding: 1px 3px;
+    background-color: rgba(0,0,0,0.1);
+    border-radius: 3px;
+}
+
+#div_id_unit_price {
+    margin-bottom: 4rem;
+}

--- a/market/templates/market/base.html
+++ b/market/templates/market/base.html
@@ -9,9 +9,11 @@
         <meta name="author" content="" />
         <title>{% translate 'Market Simulator' %} | {% block title %}{% endblock %}</title>
         <!-- Favicon-->
-        <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
+        <!-- <link rel="icon" type="image/x-icon" href="assets/favicon.ico" /> -->
         <link href="{% static "style.css" %}" rel="stylesheet" />
         <link href="{% static "bootstrap.min.css" %}" rel="stylesheet" />
+        <!-- Ion.RangeSlider CSS-->
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/ion-rangeslider/2.3.1/css/ion.rangeSlider.min.css"/>
     </head>
     <body>
         <!-- Navigation-->
@@ -68,6 +70,9 @@
         <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/js/bootstrap.bundle.min.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/js-cookie@rc/dist/js.cookie.min.js"></script>
+
+        <!-- Ion.RangeSlider JS-->
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/ion-rangeslider/2.3.1/js/ion.rangeSlider.min.js"></script>
         
         <!-- Core theme JS-->
         <!-- <script src="js/scripts.js"></script> -->

--- a/market/templates/market/play.html
+++ b/market/templates/market/play.html
@@ -201,9 +201,15 @@
 
 {% block javascript %}
 
+<script>
+// Display currency amount with 2 decimals
+function prettify (num) {
+    return num.toFixed(2);
+}
+</script>
+
 {% if not wait %}
 <script>
-
     var labels = document.getElementsByTagName('label');    
     var price_label = labels[0]
     var amount_label = labels[1]
@@ -217,48 +223,93 @@
     var balance_after_production = document.getElementById('balance_after_production');
     var profit_best_case = document.getElementById('profit_best_case')
     var profit_worst_case = document.getElementById('profit_worst_case')
+    var market_max_cost = parseFloat("{{ trader.market.max_cost }}".replace(',', '.'));
+    var market_average_price = parseFloat("{{ round_stats.all.last.avg_price }}".replace(',', '.'));
+    var round = "{{ trader.market.round }}";
 
     // only show calculations when screen width is bigger than this number
     const show_formula_breakpoint = 490;
 
-  function set_price_label(){
-      price = parseFloat(price_slider.value).toFixed(2)
-	  price_label.innerHTML = "{% translate 'Price (kr.)' %}: " + price;
+    function initializeRangeSliders() {
+        var $priceslider = $(".price-slider");
+        var $productionslider = $(".production-slider");
+
+        // Custom Marks using code from http://ionden.com/a/plugins/ion.rangeSlider/showcase.html#a_marks
+        var min = $priceslider.attr("min");
+        var max = $priceslider.attr("max");
+        function convertToPercent (num) {
+	    var percent = ((num - min) / (max - min)) * 100;
+	    return percent;
+        }
+
+        function addMark ($slider, value, description) {
+            var left = convertToPercent(value);
+            var html = '<span class="slider_mark" style="left: ' + left + '%"> '
+                       + value
+                       + ' kr. (' + description + ')</span>';
+            $slider.append(html);
+        }
+
+        $priceslider.ionRangeSlider({
+          skin: "round",
+          type: "single",
+          grid : true,
+          min: min,
+          max: max,
+          hide_min_max : true,
+          step: 0.1,
+          from: unit_prod_cost,
+          prettify : prettify ,
+          postfix : " kr.",
+          onStart: function (data) {
+              addMark(data.slider, unit_prod_cost, "din produktionspris");
+              if (round > 0) {
+    	          addMark(data.slider, market_average_price, "markedsgennemsnit.");
+              }
+          }
+        });
+
+        $productionslider.ionRangeSlider({
+          skin: "round",
+          type: "single",
+          grid : true,
+          min: $productionslider.attr("min"),
+          max: $productionslider.attr("max"),
+          hide_min_max : true,
+          step: 1,
+          from: 0,
+          postfix : " stk."
+        });
     }
-    
-  function set_amount_label(){
-	  amount_label.innerHTML = "{% translate 'Amount' %}: " + amount_slider.value;
-        //amount_label.innerHTML = "Amount: " + amount_slider.value;
-    }
-    
+
     function set_total_cost(){
         amount = amount_slider.value; 
-        total_prod_cost.innerHTML = (amount * unit_prod_cost).toFixed(2);
+        total_prod_cost.innerHTML = prettify(amount * unit_prod_cost);
         if ($(window).width() > show_formula_breakpoint) {
             formula = document.getElementById('total_prod_cost_formula')
-            formula.innerHTML = `${amount} * ${unit_prod_cost.toFixed(2)} = `;
+            formula.innerHTML = `${amount} * ${prettify(unit_prod_cost)} = `;
         } 
     }
     
     function set_potential_income(){
         amount = amount_slider.value;
         price = parseFloat(price_slider.value);
-        income_best_case.innerHTML = (amount*price).toFixed(2);
+        income_best_case.innerHTML = prettify(amount*price);
         
         if ($(window).width() > show_formula_breakpoint) { 
             formula = document.getElementById('income_best_case_formula')
-            formula.innerHTML = `${amount} * ${price.toFixed(2)} = `; 
+            formula.innerHTML = `${amount} * ${prettify(price)} = `; 
         }
     }
 
     function set_balance_after_production(){
         amount = amount_slider.value;
         costs = amount * unit_prod_cost;
-        balance_after_production.innerHTML = (balance - costs).toFixed(2);
+        balance_after_production.innerHTML = prettify(balance - costs);
 
         if ($(window).width() > show_formula_breakpoint) { 
             formula = document.getElementById('balance_after_production_formula')
-            formula.innerHTML = `${balance.toFixed(2)} - ${costs.toFixed(2)} = `;
+            formula.innerHTML = `${prettify(balance)} - ${prettify(costs)} = `;
         } 
     }
  
@@ -281,31 +332,28 @@
         } else{
             profit_worst_case.style.color = 'green'
         }
-        profit_best_case.innerHTML = best_case_profit.toFixed(2);
-        profit_worst_case.innerHTML = (-expences).toFixed(2);
+        profit_best_case.innerHTML = prettify(best_case_profit);
+        profit_worst_case.innerHTML = prettify(-expences);
 
         if ($(window).width() > show_formula_breakpoint) { 
-            document.getElementById('profit_best_case_formula').innerHTML = `${best_case_income.toFixed(2)} - ${expences.toFixed(2)} = `;
-            document.getElementById('profit_worst_case_formula').innerHTML = `0.00 - ${expences.toFixed(2)} = `;
+            document.getElementById('profit_best_case_formula').innerHTML = `${prettify(best_case_income)} - ${prettify(expences)} = `;
+            document.getElementById('profit_worst_case_formula').innerHTML = `0.00 - ${prettify(expences)} = `;
         }     
     }
 
-    set_price_label();
-    set_amount_label();
+    initializeRangeSliders();
     set_total_cost(); 
     set_potential_income()
     set_balance_after_production()
     set_potential_profit()
 
     price_slider.oninput = function () {
-        set_price_label();
         set_potential_income();
         set_balance_after_production()
         set_potential_profit();
     }
 
     amount_slider.oninput = function () {
-        set_amount_label();
         set_total_cost();
         set_potential_income();
         set_balance_after_production()
@@ -379,7 +427,7 @@
     function format_amount_labels(value, index, values){
         // Default format of 5000 on axis is 5,000. 
         // Here we change this to 5000.00
-        return value.toFixed(2) 
+        return prettify(value);
     }
     
     // Balance chart 

--- a/market/tests/test_views.py
+++ b/market/tests/test_views.py
@@ -784,12 +784,10 @@ def test_error_message_to_user_when_invalid_form(client, db):
     form = response.context['form']
 
     # Validation error msgs shown for unit price
-    assert(
-        'name="unit_price" min="0" class="slider numberinput form-control is-invalid' in str(form))
+    assert 'This field is required.</li></ul><input type="text" name="unit_price"' in str(form)
 
     # Validation error msgs not shown for unit amount
-    assert not(
-        'name="unit_amount" min="0" class="slider numberinput form-control is-invalid' in str(form))
+    assert 'This field is required.</li></ul><input type="text" name="unit_amount"' not in str(form)
 
 
 # Test CurrentRoundView

--- a/market/views.py
+++ b/market/views.py
@@ -245,6 +245,9 @@ def play(request, market_id):
     else:
         market = trader.market
 
+        round_stats = RoundStat.objects.filter(market=market)
+        trades = Trade.objects.filter(trader=trader)
+
         if request.method == 'POST':
             form = TradeForm(data=request.POST)
             if form.is_valid():
@@ -255,10 +258,11 @@ def play(request, market_id):
                 new_trade.save()
                 return redirect(reverse('market:play', args=(market.market_id,)))
         else:
-            form = TradeForm(trader)
-
-        round_stats = RoundStat.objects.filter(market=market)
-        trades = Trade.objects.filter(trader=trader)
+            if market.round == 0:
+                form = TradeForm(trader)
+            else:
+                market_average = round_stats.last().avg_price
+                form = TradeForm(trader, market_average)
 
         # Set x-axis for graphs
         if market.endless:

--- a/market/views.py
+++ b/market/views.py
@@ -258,11 +258,11 @@ def play(request, market_id):
                 new_trade.save()
                 return redirect(reverse('market:play', args=(market.market_id,)))
         else:
-            if market.round == 0:
-                form = TradeForm(trader)
-            else:
+            if market.round > 0 and round_stats.last() is not None:
                 market_average = round_stats.last().avg_price
                 form = TradeForm(trader, market_average)
+            else:
+                form = TradeForm(trader)
 
         # Set x-axis for graphs
         if market.endless:


### PR DESCRIPTION
Attempt at fixing #69 and #167.

Now looks like this on desktop:
![Screenshot 2021-09-22 at 20 33 57](https://user-images.githubusercontent.com/55204/134401708-d0b06b46-3a81-4fa0-a050-1ff5bbc76b3c.png)

On an iPhone size screen it's like this:
![Screenshot 2021-09-22 at 20 33 18](https://user-images.githubusercontent.com/55204/134401662-8f52d63c-6f9c-4170-a3fb-3b4853cb30f5.png)

The two labels can overlap, which might be annoying, but I think this is perhaps the best we can do.

Tests are still TODO, so it shouldn't be merged right away.