### PR TITLE
web service (gunicorn) doesn't need access to backup directory

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -7,7 +7,6 @@ services:
     command: /bin/sh -c /code/entrypoint.prod.sh
     volumes:
       - static_volume:/code/static
-      - ./backups:/backups
     expose:
       - 8000
     env_file:


### PR DESCRIPTION
Final change to make backups work in production.